### PR TITLE
Configure only one executer on Jenkins Master 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
 
   #Jenkins master setup
   master_cert2017:
-    image: jenkins:2.19.4
+    build: jenkinsM/
     ports:
      - "8080:8080"
      - "50000:50000"

--- a/jenkinsM/Dockerfile
+++ b/jenkinsM/Dockerfile
@@ -1,0 +1,5 @@
+# This Dockerfile configures basic slave
+FROM jenkins:2.19.4
+MAINTAINER Raul Pareja <raul.pareja@gmail.com>
+USER jenkins
+COPY ./groovy-scripts/masterexecutors.groovy /usr/share/jenkins/ref/init.groovy.d/masterexecutors.groovy

--- a/jenkinsM/groovy-scripts/masterexecutors.groovy
+++ b/jenkinsM/groovy-scripts/masterexecutors.groovy
@@ -1,0 +1,5 @@
+//Want to reduce the amount of executors on master to only 1
+//because it may be needed to run sed jobs with DSL
+
+import jenkins.model.*
+Jenkins.instance.setNumExecutors(1)


### PR DESCRIPTION
Set only one executor for the Jenkins Master, in case we need to create seed job DSL to auto-configure it.

The rest of jobs should be run on any of the slaves