### PR TITLE
Update README and .gitignore for new jenkins master  volume name 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 #don't track volumes
-new_jenkins_volume/
+jenkins_master_volume/
 
 #Don't track neither
 .bash_history

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ https://github.com/jenkinsci/docker/blob/master/README.md
 
 * Docker version 1.12.6 or above
 * docker-compose version 1.9.0 or above
-* create a directory to host the jenkins master volume, call it new_jenkins_volume or edit docker-compose.yml file
+* create a directory to host the jenkins master volume, call it jenkins_master_volume/ or edit docker-compose.yml file
 
 Please notice that exposure of port 50000 is only needed in case you need JNLP, in case you want to add a windows node as slave via JNLP.
 
@@ -34,6 +34,14 @@ Run it with docker-compose and in daemon mode forcing build at least the very fi
 ```
 COMPOSE_HTTP_TIMEOUT=200 docker-compose up -d --build
 ```
+
+The very first time you will need to provide the "initialAdminPassword" from /var/jenkins_home/secrets/initialAdminPassword, but as we have a volume we can just browse there and get it, and paste it into the jenkins web GUI
+
+```
+prompt$ cd jenkins_master_volume/
+prompt$ cat secrets/initialAdminPassword 
+```
+
 
 ### How to stop and remove the cotnainers
 ```

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ https://github.com/jenkinsci/docker/blob/master/README.md
 
 Please notice that exposure of port 50000 is only needed in case you need JNLP, in case you want to add a windows node as slave via JNLP.
 
-### How to build and run the containers
+### How to build and run the containers + basic config of jenkins
 
 Run it with docker-compose and in daemon mode forcing build at least the very first time
 ```
@@ -41,7 +41,7 @@ The very first time you will need to provide the "initialAdminPassword" from /va
 prompt$ cd jenkins_master_volume/
 prompt$ cat secrets/initialAdminPassword 
 ```
-
+For the certification jenkins lab, is recommended to just install the suggested plugins
 
 ### How to stop and remove the cotnainers
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
      - "8080:8080"
      - "50000:50000"
     volumes:
-     - /home/mishkin/Docker/new_jenkins/new_jenkins_volume:/var/jenkins_home
+     - ./jenkins_master_volume:/var/jenkins_home
     networks:
       cinet:
         ipv4_address: 192.168.250.2


### PR DESCRIPTION
* .gitignore updated to skip the volume name for the jenkins master
* README updated with how to get the initialpassword and recommend to install just suggested plugins